### PR TITLE
Fixes to unittests

### DIFF
--- a/tests/model_selection/dask_searchcv/test_model_selection.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection.py
@@ -1031,7 +1031,7 @@ def test_sample_weight_cross_validation(
     gscv = dcv.GridSearchCV(
         estimator,
         estimator_params,  # parameters
-        scoring=make_scorer(metric, greater_is_better, needs_proba),
+        scoring=make_scorer(score_func=metric, greater_is_better=greater_is_better, needs_proba=needs_proba),
         cv=2,
         return_train_score=True
     )


### PR DESCRIPTION
================ 663 passed, 8 skipped, 14 xfailed, 2 xpassed, 142 warnings in 214.74s (0:03:34) =================
(dask-ml-dev-skl024)

After installing Scikit-learn nightly build into dask-ml's ci latest env via:
`pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn==0.24.dev0`